### PR TITLE
Fix restart button resetting game loop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ const App: React.FC = () => {
   });
 
   useEffect(() => {
+    if (gameOver) return;
     const canvas = canvasRef.current;
     if (!canvas) return;
     const ctx = canvas.getContext("2d");
@@ -176,7 +177,7 @@ const App: React.FC = () => {
     frameId = requestAnimationFrame(gameLoop);
 
     return () => cancelAnimationFrame(frameId);
-  }, [keys]);
+  }, [keys, gameOver]);
 
   const handleRestart = () => {
     setGameOver(false);


### PR DESCRIPTION
## Summary
- stop the game loop when `gameOver` is true
- restart the loop when the game is restarted

## Testing
- `yarn lint`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68680a0a3d4c832eb8ca7e956e41d5fd