### PR TITLE
Add alien sprite animations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import { GameOverOverlay } from "./components/GameOverOverlay";
 import { useKeyboardControls } from "./hooks/useKeyboardControls";
 import { generateEnemies } from "./utils/enemyFormation";
 import { isColliding } from "./utils/collision";
-import { Entity } from "./types";
+import { Entity, Enemy } from "./types";
 
 const CANVAS_WIDTH = 800;
 const CANVAS_HEIGHT = 600;
@@ -19,6 +19,11 @@ const PLAYER_SPEED = 5;
 const ENEMY_SPEED_INITIAL = 2;
 const ENEMY_SPEED_INCREMENT = 0.5;
 
+const SPRITE_SIZE = 48;
+const SPAWN_FRAME_DURATION = 100; // 500ms over 5 frames
+const NORMAL_FRAME_DURATION = 200; // 5 fps
+const HIT_FRAME_DURATION = 60; // 300ms over 5 frames
+
 const App: React.FC = () => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const keys = useKeyboardControls();
@@ -26,7 +31,7 @@ const App: React.FC = () => {
   const [gameOver, setGameOver] = useState(false);
 
   const bullets = useRef<Entity[]>([]);
-  const enemies = useRef<Entity[]>(
+  const enemies = useRef<Enemy[]>(
     generateEnemies(5, 10, 60, 50, 50, 50, ENEMY_SIZE)
   );
   const direction = useRef<1 | -1>(1);
@@ -49,7 +54,7 @@ const App: React.FC = () => {
     if (!ctx) return;
 
     const invaderImage = new Image();
-    invaderImage.src = "/assets/invader1.svg";
+    invaderImage.src = "/assets/alien-sprite.png";
     let imageLoaded = false;
     invaderImage.onload = () => {
       imageLoaded = true;
@@ -59,6 +64,7 @@ const App: React.FC = () => {
 
     const gameLoop = () => {
       const p = player.current;
+      const now = performance.now();
 
       // Movement
       if (keys.current.left && p.x > 0) p.x -= PLAYER_SPEED;
@@ -104,19 +110,49 @@ const App: React.FC = () => {
         }));
       }
 
-      // Collision detection
-      const remainingEnemies: Entity[] = [];
+      // Update enemy state and handle collisions/animation
+      const remainingEnemies: Enemy[] = [];
       for (const enemy of enemies.current) {
-        let hit = false;
-        bullets.current = bullets.current.filter((b) => {
-          if (!hit && isColliding(b, enemy)) {
-            score.current += 10;
-            hit = true;
-            return false;
+        if (enemy.state !== 'hit') {
+          bullets.current = bullets.current.filter((b) => {
+            if (isColliding(b, enemy)) {
+              score.current += 10;
+              enemy.state = 'hit';
+              enemy.row = 1;
+              enemy.frame = 0;
+              enemy.opacity = 1;
+              enemy.nextFrameTime = now + HIT_FRAME_DURATION;
+              return false;
+            }
+            return true;
+          });
+        }
+
+        if (now >= enemy.nextFrameTime) {
+          if (enemy.state === 'spawning') {
+            enemy.frame += 1;
+            if (enemy.frame >= 5) {
+              enemy.state = 'normal';
+              enemy.row = 0;
+              enemy.frame = Math.floor(Math.random() * 5);
+              enemy.nextFrameTime = now + NORMAL_FRAME_DURATION;
+            } else {
+              enemy.nextFrameTime = now + SPAWN_FRAME_DURATION;
+            }
+          } else if (enemy.state === 'normal') {
+            enemy.frame = (enemy.frame + 1) % 5;
+            enemy.nextFrameTime = now + NORMAL_FRAME_DURATION;
+          } else if (enemy.state === 'hit') {
+            enemy.frame += 1;
+            enemy.opacity = 1 - enemy.frame / 5;
+            if (enemy.frame >= 5) {
+              continue; // remove enemy
+            }
+            enemy.nextFrameTime = now + HIT_FRAME_DURATION;
           }
-          return true;
-        });
-        if (!hit) remainingEnemies.push(enemy);
+        }
+
+        remainingEnemies.push(enemy);
       }
       enemies.current = remainingEnemies;
 
@@ -151,9 +187,22 @@ const App: React.FC = () => {
       // Enemies (use image or fallback)
       enemies.current.forEach((e) => {
         if (imageLoaded) {
-          // ctx.drawImage(invaderImage, e.x, e.y, e.width, e.height);
-          const scale = ENEMY_SIZE / invaderImage.width;
-          ctx.drawImage(invaderImage, e.x, e.y, ENEMY_SIZE * scale, ENEMY_SIZE * scale);
+          const sx = e.frame * SPRITE_SIZE;
+          const sy = e.row * SPRITE_SIZE;
+          ctx.save();
+          ctx.globalAlpha = e.opacity;
+          ctx.drawImage(
+            invaderImage,
+            sx,
+            sy,
+            SPRITE_SIZE,
+            SPRITE_SIZE,
+            e.x,
+            e.y,
+            ENEMY_SIZE,
+            ENEMY_SIZE
+          );
+          ctx.restore();
         } else {
           ctx.fillStyle = "red";
           ctx.fillRect(e.x, e.y, e.width, e.height);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,3 +10,15 @@ export interface Keys {
   right: boolean;
   space: boolean;
 }
+
+export interface Enemy extends Entity {
+  state: 'spawning' | 'normal' | 'hit';
+  /** current animation frame index */
+  frame: number;
+  /** sprite sheet row used for current animation */
+  row: number;
+  /** timestamp when the next frame should be shown */
+  nextFrameTime: number;
+  /** opacity used when fading out */
+  opacity: number;
+}

--- a/src/utils/enemyFormation.ts
+++ b/src/utils/enemyFormation.ts
@@ -1,4 +1,4 @@
-import { Entity } from '../types';
+import { Enemy } from '../types';
 
 export const generateEnemies = (
   rows = 5,
@@ -8,12 +8,18 @@ export const generateEnemies = (
   offsetX = 50,
   offsetY = 50,
   size = 10
-): Entity[] =>
+): Enemy[] =>
   Array.from({ length: rows }, (_, i) =>
     Array.from({ length: cols }, (_, j) => ({
       x: offsetX + j * spacingX,
       y: offsetY + i * spacingY,
       width: size,
       height: size,
+      state: 'spawning' as const,
+      frame: 0,
+      // randomly pick spawn row 2 (index 2) or 3 (index 3)
+      row: Math.random() < 0.5 ? 2 : 3,
+      nextFrameTime: performance.now() + 100,
+      opacity: 1,
     }))
   ).flat();


### PR DESCRIPTION
## Summary
- define `Enemy` interface to hold animation state
- spawn enemies using new interface with animation metadata
- animate spawn, idle, and hit states with `alien-sprite.png`

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_686813e3ba4c832e9685a542b8efe360