### PR TITLE
Add player firing animation

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,3 +22,16 @@ export interface Enemy extends Entity {
   /** opacity used when fading out */
   opacity: number;
 }
+
+export interface Player extends Entity {
+  /** current animation frame index */
+  frame: number;
+  /** sprite sheet row used for current animation */
+  row: number;
+  /** timestamp when the next frame should be shown */
+  nextFrameTime: number;
+  /** true if the firing animation is active */
+  firing: boolean;
+  /** how many animation steps have played in the current firing cycle */
+  firingStep: number;
+}


### PR DESCRIPTION
## Summary
- define `Player` interface for firing animation state
- animate capsule sprite frames on firing
- remove binary asset from repo

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68683f3b63a0832e91f86fd7c9033028