### PR TITLE
Add formation parsing helper

### DIFF
--- a/src/utils/getEnemyPositions.ts
+++ b/src/utils/getEnemyPositions.ts
@@ -1,0 +1,17 @@
+export type EnemyType = 'empty' | 'enemy'
+export type Formation = EnemyType[][]
+
+export const getEnemyPositions = (
+  formation: Formation
+): { x: number; y: number }[] => {
+  const positions: { x: number; y: number }[] = []
+  for (let y = 0; y < formation.length; y += 1) {
+    const row = formation[y]
+    for (let x = 0; x < row.length; x += 1) {
+      if (row[x] !== 'empty') {
+        positions.push({ x, y })
+      }
+    }
+  }
+  return positions
+}


### PR DESCRIPTION
## Summary
- define `EnemyType` and `Formation`
- add `getEnemyPositions` utility to convert a formation grid into enemy coordinates

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_687a974442b4832eb68b4681615bc59e