### PR TITLE
feat: add support for enemy formations

### DIFF
--- a/src/components/Invaders.tsx
+++ b/src/components/Invaders.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useImperativeHandle, useRef } from 'react';
 import { Enemy, Entity } from '../types';
-import { generateEnemies } from '../utils/enemyFormation';
+import { generateEnemies, levelOneFormation } from '../utils/enemyFormation';
 import { isColliding } from '../utils/collision';
 
 export interface InvadersHandles {
@@ -20,7 +20,9 @@ const HIT_FRAME_DURATION = 60;
 const SPRITE_SIZE = 48;
 
 export const Invaders = forwardRef<InvadersHandles>((_, ref) => {
-  const enemies = useRef<Enemy[]>(generateEnemies(5, 10, 60, 50, 50, 50, ENEMY_SIZE));
+  const enemies = useRef<Enemy[]>(
+    generateEnemies(levelOneFormation, 10, 60, 50, 50, 50, ENEMY_SIZE),
+  );
   const direction = useRef<1 | -1>(1);
   const enemySpeed = useRef(ENEMY_SPEED_INITIAL);
   const score = useRef(0);
@@ -95,7 +97,15 @@ export const Invaders = forwardRef<InvadersHandles>((_, ref) => {
 
       if (enemies.current.length === 0) {
         enemySpeed.current += ENEMY_SPEED_INCREMENT;
-        enemies.current = generateEnemies(5, 10, 60, 50, 50, 50, ENEMY_SIZE);
+        enemies.current = generateEnemies(
+          levelOneFormation,
+          10,
+          60,
+          50,
+          50,
+          50,
+          ENEMY_SIZE,
+        );
         bullets.current = [];
         direction.current = 1;
       }
@@ -126,7 +136,15 @@ export const Invaders = forwardRef<InvadersHandles>((_, ref) => {
       });
     },
     reset() {
-      enemies.current = generateEnemies(5, 10, 60, 50, 50, 50, ENEMY_SIZE);
+      enemies.current = generateEnemies(
+        levelOneFormation,
+        10,
+        60,
+        50,
+        50,
+        50,
+        ENEMY_SIZE,
+      );
       enemySpeed.current = ENEMY_SPEED_INITIAL;
       direction.current = 1;
       score.current = 0;

--- a/src/utils/enemyFormation.ts
+++ b/src/utils/enemyFormation.ts
@@ -1,25 +1,61 @@
 import { Enemy } from '../types';
 
+export type FormationMatrix = number[][];
+
+export const levelOneFormation: FormationMatrix = [
+  [0, 1, 1, 1, 1, 1, 0],
+  [1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1],
+  [0, 1, 1, 1, 1, 1, 0],
+];
+
 export const generateEnemies = (
-  rows = 5,
+  formationOrRows: FormationMatrix | number = 5,
   cols = 10,
   spacingX = 60,
   spacingY = 50,
   offsetX = 50,
   offsetY = 50,
-  size = 10
-): Enemy[] =>
-  Array.from({ length: rows }, (_, i) =>
-    Array.from({ length: cols }, (_, j) => ({
-      x: offsetX + j * spacingX,
-      y: offsetY + i * spacingY,
-      width: size,
-      height: size,
-      state: 'spawning' as const,
-      frame: 0,
-      // randomly pick spawn row 2 (index 2) or 3 (index 3)
-      row: Math.random() < 0.5 ? 2 : 3,
-      nextFrameTime: performance.now() + 100,
-      opacity: 1,
-    }))
-  ).flat();
+  size = 10,
+  baseCols = 10,
+  baseRows = 5,
+): Enemy[] => {
+  const formation: FormationMatrix =
+    typeof formationOrRows === 'number'
+      ? Array.from({ length: formationOrRows }, () =>
+          Array.from({ length: cols }, () => 1),
+        )
+      : formationOrRows;
+
+  const usedRows = formation.length;
+  const usedCols = formation.reduce(
+    (max, row) => Math.max(max, row.length),
+    0,
+  );
+
+  const centeredOffsetX = offsetX + ((baseCols - usedCols) * spacingX) / 2;
+  const centeredOffsetY = offsetY + ((baseRows - usedRows) * spacingY) / 2;
+
+  const enemies: Enemy[] = [];
+  for (let i = 0; i < formation.length; i += 1) {
+    const row = formation[i];
+    for (let j = 0; j < row.length; j += 1) {
+      if (row[j]) {
+        enemies.push({
+          x: centeredOffsetX + j * spacingX,
+          y: centeredOffsetY + i * spacingY,
+          width: size,
+          height: size,
+          state: 'spawning',
+          frame: 0,
+          // randomly pick spawn row 2 (index 2) or 3 (index 3)
+          row: Math.random() < 0.5 ? 2 : 3,
+          nextFrameTime: performance.now() + 100,
+          opacity: 1,
+        });
+      }
+    }
+  }
+
+  return enemies;
+};


### PR DESCRIPTION
## Summary
- allow generateEnemies to accept formation matrices or row/column counts
- center smaller formations by offset adjustment
- export levelOneFormation and use it for initial invader setup

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68966fca9248832eb67c2d0fdd526605